### PR TITLE
Add path suffix options to CMake configuration. Allow to detect Catch

### DIFF
--- a/cmake/Modules/FindCatch.cmake
+++ b/cmake/Modules/FindCatch.cmake
@@ -1,6 +1,7 @@
 find_path(
 	CATCH_INCLUDE_DIR 
 	NAMES catch.hpp
+	PATH_SUFFIXES catch2
 	DOC "catch include dir"
 )
 


### PR DESCRIPTION
Minor improvement in the FindCatch cmake file for portability